### PR TITLE
Renamed constructors to __construct

### DIFF
--- a/Fork.php
+++ b/Fork.php
@@ -1,7 +1,7 @@
 <?php
 /* vim: set expandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 // +----------------------------------------------------------------------+
-// | PHP Version 4 - 5                                                       |
+// | PHP Version 4 - 7                                                    |
 // +----------------------------------------------------------------------+
 // | Copyright (c) 1997-2003 The PHP Group                                |
 // +----------------------------------------------------------------------+
@@ -37,7 +37,7 @@ define ('PHP_FORK_RETURN_METHOD', 	-2);
  *  class executeThread extends PHP_Fork {
  *     var $counter;
  *
- *     function executeThread($name)
+ *     function __construct($name)
  *     {
  *         $this->PHP_Fork($name);
  *         $this->counter = 0;
@@ -198,7 +198,7 @@ class PHP_Fork {
      * @access public
      * @return bool true if the Shared Memory Segments are OK, false otherwise.<br>Notice that only if shared mem is ok the process will be forked.
      */
-    function PHP_Fork($name, $puid = 0, $guid = 0, $umask = -1)
+    function __construct($name, $puid = 0, $guid = 0, $umask = -1)
     {
         $this->_running = false;
 

--- a/Fork.php
+++ b/Fork.php
@@ -174,7 +174,7 @@ class PHP_Fork {
     var $_running;
 
     /**
-     * PHP_Fork::PHP_Fork()
+     * PHP_Fork::__construct()
      * Allocates a new pseudo-thread object and set its name to $name.
      * Optionally, set a PUID, a GUID and a UMASK for the child process.
      * This also initialize Shared Memory Segments for process communications.

--- a/examples/basic.php
+++ b/examples/basic.php
@@ -29,7 +29,7 @@ define ("NUM_THREAD", 2);
 class executeThread extends PHP_Fork {
     var $counter;
 
-    function executeThread($name)
+    function __construct($name)
     {
         $this->PHP_Fork($name);
         $this->counter = 0;

--- a/examples/browser_pool.php
+++ b/examples/browser_pool.php
@@ -49,7 +49,7 @@ declare (ticks = 1);
 class executeThread extends PHP_Fork {
         var $request;
 
-        function executeThread($name)
+        function __construct($name)
         {
                 $this->PHP_Fork($name);
         }

--- a/examples/exec_methods.php
+++ b/examples/exec_methods.php
@@ -47,7 +47,7 @@ declare (ticks = 1);
  * and to the child (and will be executed into the relative process)
  */
 class executeThread extends PHP_Fork {
-    function executeThread($name)
+    function __construct($name)
     {
         $this->PHP_Fork($name);
         $GLOBALS["counter"] = 0;

--- a/examples/passing_vars.php
+++ b/examples/passing_vars.php
@@ -32,7 +32,7 @@ define ("NUM_THREAD", 2);
 class executeThread extends PHP_Fork {
     var $counter;
 
-    function executeThread($name)
+    function __construct($name)
     {
         $this->PHP_Fork($name);
         $this->counter = 0;

--- a/examples/simple_controller.php
+++ b/examples/simple_controller.php
@@ -40,7 +40,7 @@ define ("CTRL_POLLING_INTERVAL", 5);
 class executeThread extends PHP_Fork {
     var $counter;
 
-    function executeThread($name)
+    function __construct($name)
     {
         $this->PHP_Fork($name);
         $this->counter = 0;
@@ -91,7 +91,7 @@ class controllerThread extends PHP_Fork {
      * @param  $interval
      * @return
      */
-    function controllerThread($name, &$executeThreadPool, $maxIdleTime = 60, $interval = 60)
+    function __construct($name, &$executeThreadPool, $maxIdleTime = 60, $interval = 60)
     {
         $this->PHP_Fork($name);
         $this->_sleepInt = $interval;


### PR DESCRIPTION
Using PHP_Fork in php v7 gives the following error
```
PHP ERROR #8192: Methods with the same name as their class will not be constructors in a future version of PHP
```

This commit remove that error message by renaming the constructors to `__construct`